### PR TITLE
Embed git revision in function sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 EXTVERSION   = dev
+EXTREVISION  = $(shell test -d .git && which git > /dev/null && git describe --always)
 
 META         = META.json
 EXTENSION    = $(shell grep -m 1 '"name":' $(META).in | sed -e 's/[[:space:]]*"name":[[:space:]]*"\([^"]*\)",/\1/')
@@ -22,7 +23,7 @@ ifeq ($(PG91),yes)
 all: sql/$(EXTENSION)--$(EXTVERSION).sql
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql $(META)
-	cp $< $@
+	$(SED) -e 's/$$Id$$/$(EXTREVISION)/' $< > $@
 
 $(META): $(META).in
 	$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' $< > $@

--- a/sql/dbpatch.sql
+++ b/sql/dbpatch.sql
@@ -32,6 +32,7 @@ CREATE OR REPLACE FUNCTION apply_patch(
 RETURNS
     BOOLEAN AS
 $$
+-- $Id$
 DECLARE
     v_sql TEXT;
 BEGIN
@@ -82,6 +83,7 @@ CREATE OR REPLACE FUNCTION apply_patch(
 RETURNS
     BOOLEAN AS
 $$
+    -- $Id$
     SELECT @extschema@.apply_patch($1, ARRAY[$2])
 $$
     LANGUAGE sql;


### PR DESCRIPTION
So there's a way to tell which git commit did function
definitions come from.

NOTE this still doesn't tell you which revision did *table*
definition came from