### PR TITLE
Make sure all upgrade scripts are always installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes for the PostgreSQL dbpatch extension are documented
 in this file.
 
 ## [1.4.1dev] - 2019-MM-DD
+### Fixed
+- Installation of upgrade scripts on `make install` (#44)
 
 ## [1.4.0] - 2019-01-14
 ### Improved

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,11 @@ UPGRADEABLE_VERSIONS = 1.0.0 1.0.1 1.1.0dev 1.1.0 \
   1.2.0dev 1.2.0 \
   1.3.0dev 1.3.0
 
+UPGRADE_SCRIPTS_BUILT = $(patsubst %,upgrade-scripts/$(EXTENSION)--%--$(EXTVERSION).sql,$(UPGRADEABLE_VERSIONS))
+
 DATA_built = \
   $(EXTENSION)--$(EXTVERSION).sql \
-  $(wildcard upgrade-scripts/*--*.sql)
+  $(UPGRADE_SCRIPTS_BUILT)
 DATA         = $(wildcard sql/*--*.sql)
 DOCS         = $(wildcard doc/*.md)
 TESTS        = $(wildcard test/sql/*.sql)
@@ -74,6 +76,8 @@ endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+$(UPGRADE_SCRIPTS_BUILT): upgrade-scripts
 
 .PHONY: upgrade-scripts
 upgrade-scripts: $(EXTENSION)--$(EXTVERSION).sql


### PR DESCRIPTION
Did otherwise fail to install with `make install` without prior
`make` call.

This is a  backport of PR #43