### PR TITLE
Fix --version switch handling

### DIFF
--- a/dbpatch-loader.sh
+++ b/dbpatch-loader.sh
@@ -16,7 +16,8 @@ while test -n "$1"; do
   if test "$1" = "--no-extension"; then
     EXT_MODE=off
   elif test "$1" = "--version"; then
-    VER=$1; shift
+    shift
+    VER=$1;
   elif test -z "${TGT_DB}"; then
     TGT_DB=$1
   elif test -z "${TGT_SCHEMA}"; then


### PR DESCRIPTION
I don't know since when the switch is broken.
May be forever, in which case it could be a good moment to
change the name, so that `--version` can be used to report
extension version ?