### PR TITLE
ci: also build in release branches, and on tag push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
       - packagecloud
+      - 'release-*'
+    tags:
+      - '*'
 
 jobs:
 
@@ -113,7 +116,9 @@ jobs:
         if test "${{ github.event_name }}" = 'push'; then
           if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
             REPO=test
-          else
+          elif test "${{ github.ref }}" = 'refs/heads/packagecloud' \
+                 -o "${{ github.ref }}" = 'refs/heads/master'
+          then
             REPO=dev
           fi
         fi


### PR DESCRIPTION
We saw this needed in other repos