### PR TITLE
ci: migrate to secure environment setting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,7 @@ jobs:
             REPO=dev
           fi
         fi
-        echo "REPO: $REPO"
-        echo ::set-env name=REPO::"$REPO"
+        echo "REPO=$REPO" | tee -a $GITHUB_ENV
 
     - uses: linz/linz-software-repository@v4
       with:


### PR DESCRIPTION
See
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/