### PR TITLE
fix: Don't treat missing revision as an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 EXTVERSION = $(lastword $(UPGRADEABLE_VERSIONS))
 REVISION  = $(shell git describe --always)
 ifeq ($(REVISION),)
-$(error "REVISION is empty")
+$(warning "REVISION is empty")
 endif
 
 PREFIX ?= /usr/local


### PR DESCRIPTION
This error handling broke the postgresql-tableversion package.