### PR TITLE
docs: Enable running installcheck with Nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ You need to run the test suite using a super user, such as the default "postgres
 
     make installcheck PGUSER=postgres
 
+Using Nix:
+
+```shell
+working_directory="$(mktemp --directory)" \
+&& echo "$working_directory" \
+&& export DESTDIR="${working_directory}/build" PGDATA="${working_directory}/postgres" \
+&& export PGHOST="$PGDATA" \
+&& nix-shell --keep PGDATA --pure --run 'initdb' \
+&& nix-shell --keep PGDATA --keep PGHOST --pure --run 'pg_ctl --log="${PGDATA}/postgres.log" --options=--unix_socket_directories="$PGHOST" start' \
+&& nix-shell --keep DESTDIR --keep PGHOST --pure --run 'make all check install installcheck' \
+&& nix-shell --keep PGDATA --pure --run 'pg_ctl stop'
+```
+
 ## Building Debian packaging
 
 Build the Debian packages using the following command:

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,14 @@ pkgs.mkShell {
     pkgs.docker
     pkgs.gitFull
     pkgs.nodejs
+    (
+      pkgs.postgresql.withPackages (
+        ps: [
+          ps.pgtap
+        ]
+      )
+    )
+    pkgs.perlPackages.TAPParserSourceHandlerpgTAP
     pkgs.pre-commit
     pkgs.which
   ];


### PR DESCRIPTION
Based on <https://mgdm.net/weblog/postgresql-in-a-nix-shell/>.