### PR TITLE
fix: Enable manual triggering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
Allows running a release PR after the previous build creates a Debian changelog commit
<https://github.com/peter-evans/create-pull-request/issues/48>.